### PR TITLE
Fix the household getter on person

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -17,6 +17,7 @@ class Person < ActiveRecord::Base
   belongs_to :household, autosave: true
   has_one :user, autosave: true
   validates_presence_of :firstname, :lastname
+  alias_method :original_household, :household
 
   def fullname
     if lastname
@@ -34,6 +35,6 @@ class Person < ActiveRecord::Base
   end
 
   def household
-    @household ||= Household.new(person: self)
+    return self.original_household || Household.new(person: self)
   end
 end


### PR DESCRIPTION
Active record doesn't actually set attributes for us, so
we can't rely on @household to be populated.  We need to alias
the original household method to something new so that we can retain
that original logic to lookup the relationship of household for a person.