### PR TITLE
Hide new and edit buttons for person when permissions are insufficient

### DIFF
--- a/app/assets/javascripts/people.js
+++ b/app/assets/javascripts/people.js
@@ -12,10 +12,14 @@ function updateNewPersonButton(input) {
     }
 }
 
-function updatePersonSearch(input, users_only) {
+function updatePersonSearch(input, users_only, show_new_button) {
     users_only = typeof users_only !== 'undefined' ? true : false
+    show_new_button = typeof show_new_button !== 'undefined' ? true : false
 
-    updateNewPersonButton(input);
+    if ( show_new_button ) {
+        updateNewPersonButton(input);
+    }
+
     var data = {ajax: true}
 
     if (input.value.length > 0) {

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -13,6 +13,7 @@ class PeopleController < ApplicationController
   # GET /people/search
   # GET /people/search.json
   def search
+
     rowlimit = params[:rowlimit] || 10
     if (params[:search])
       search_keys = JSON.parse(params[:search]).to_a

--- a/app/views/people/_onkeyup_search.erb
+++ b/app/views/people/_onkeyup_search.erb
@@ -1,1 +1,5 @@
+<% if current_user and current_user.has_access?(PERM_RW_PERSON) %>
+updatePersonSearch(this, false, true);
+<% else %>
 updatePersonSearch(this);
+<% end %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -71,7 +71,7 @@
 
 <div class="row space-above collapse">
   <div class="large-8 radius large-centered columns">
-    <%= link_to 'Edit', edit_person_path(@person), :class => 'button tiny' %>
+    <%= link_to('Edit', edit_person_path(@person), :class => 'button tiny') if current_user and current_user.has_access?(PERM_RW_PERSON) %>
 
     <%= link_to 'New Visit', new_visit_path(:person_id => @person, :host_id => current_user.id), :class => 'button tiny' %>
   </div>


### PR DESCRIPTION
When a user does not have the RW person permission they should not see the edit person button on the show person page and they should not see the add person on the search person page.

Fixes #144