### PR TITLE
Fixes a search bug that causes a hard crash

### DIFF
--- a/app/views/people/_search_results.html.erb
+++ b/app/views/people/_search_results.html.erb
@@ -8,7 +8,7 @@
           # Find people with duplicate fullnames. If there is a duplicate, then the label should have <name> (<email>)
           # to help differentiate the people.
           @duplicate_name = @people.select { |p| p.id != person.id && p.fullname == person.fullname }
-          label = @duplicate_name.any? ? "#{person.fullname} (#{person.user.email})" : person.fullname
+          label = @duplicate_name.any? ? "#{person.fullname} (#{person.email})" : person.fullname
         %>
             <li class="<%= rowclass %>" onclick="window.location = '<%= url_for person_path(person) %>';">
               <div><%= label %></div>


### PR DESCRIPTION
When multiple users have the same first/last name the _search form adds
their email to the display inside of parentheses.  The email was being pulled
from person.user.email which doesn't exist for a person that is not a user since
person.user is nil.  The email should come from person.email.