### PR TITLE
Require Email Confirmation for Users

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,3 +23,11 @@ label.required:after {
     content: " *";
     color: red;
 }
+
+.green-text {
+    color: #43AC6A;
+}
+
+.red-text {
+    color: #f04124;
+}

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -143,6 +143,7 @@ class PeopleController < ApplicationController
     end
   end
 
+  # This is an AJAX only method, there is no page to be displayed.  It just invokes an action.
   def send_confirmation_email
     if not @person.user.nil? and @person.user.has_pending_email_change?
       @person.user.send_confirmation_email
@@ -150,6 +151,7 @@ class PeopleController < ApplicationController
     render :nothing => true, :status => 200, :content_type => 'text/html'
   end
 
+  # This is an AJAX only method, there is no page to be displayed.  It just invokes an action.
   def cancel_pending_email_change
     if not @person.user.nil?
       @person.user.cancel_pending_email_change
@@ -158,6 +160,7 @@ class PeopleController < ApplicationController
     render :nothing => true, :status => 200, :content_type => 'text/html'
   end
 
+  # This page does not require authentication
   def confirm_email_change
     if not @person.user.nil? and @person.user.has_pending_email_change?
       if params[:confirmation_token] != @person.user.reset_email_token
@@ -222,7 +225,7 @@ class PeopleController < ApplicationController
             if new_user.valid?
               @person.user = new_user
             else
-              errors << new_user.errors.full_messages
+              errors += new_user.errors.full_messages
             end
           else
             # We need to make sure the users email is always in-sync with the persons email
@@ -242,7 +245,7 @@ class PeopleController < ApplicationController
           end
         end
         @person.update(person_params)
-        if not @person.user.nil? and @person.user.send_confirmation
+        if not @person.user.nil? and @person.user.should_send_confirmation_email?
           @person.user.send_confirmation_email
         end
 

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -217,6 +217,10 @@ class PeopleController < ApplicationController
           end
         end
         @person.update(person_params)
+        if not @person.user.nil? and @person.user.send_confirmation
+          @person.user.send_confirmation_email
+        end
+
         # We need to raise a rollback exception if we don't validate
         # It will get caught by the broader Exception rescue and then get re-escalated
         # which may seem redunant, and it is, but we still need the broader Exception

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -1,7 +1,13 @@
 class PeopleController < ApplicationController
   before_action :set_person, only: [:show, :edit, :update, :destroy, :cancel_pending_email_change, :send_confirmation_email, :confirm_email_change]
   before_action :authenticate_user!
-  before_action :authorize_person
+  before_action :init
+
+  def init
+    @errors = []
+    authorize_person
+  end
+
   # GET /people
   # GET /people.json
   def index
@@ -198,7 +204,9 @@ class PeopleController < ApplicationController
             @person.errors.add(:email, 'is not valid')
           end
           if not @person.user
-            @person.user = User.new({email: params[:person][:email], password: Devise.friendly_token.first(8)})
+            new_user = User.new({email: params[:person][:email], password: Devise.friendly_token.first(8)})
+            new_user.confirm_email_change
+            @person.user = new_user
           else
             # We don't need to make sure the users email is always in-sync with the persons email
             # ideally we'd just store this in one place but devise requires email to be in the

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -169,6 +169,11 @@ class PeopleController < ApplicationController
         @person.email = @person.user.email
         @person.save
       end
+      if not @person.valid? or not @person.user.valid?
+        @errors = []
+        @errors += @person.errors.full_messages
+        @errors += @person.user.errors.full_messages
+      end
       render 'users/email/confirm_email_change'
       return
     end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -142,7 +142,7 @@ class PeopleController < ApplicationController
     if not @person.user.nil? and @person.user.has_pending_email_change?
       @person.user.send_confirmation_email
     end
-    render :nothing => true, :status => 200, :content_type => 'application/json'
+    render :nothing => true, :status => 200, :content_type => 'text/html'
   end
 
   def cancel_pending_email_change
@@ -150,7 +150,7 @@ class PeopleController < ApplicationController
       @person.user.cancel_pending_email_change
       @person.save
     end
-    render :nothing => true, :status => 200, :content_type => 'application/json'
+    render :nothing => true, :status => 200, :content_type => 'text/html'
   end
 
   def confirm_email_change
@@ -161,7 +161,7 @@ class PeopleController < ApplicationController
         @person.save
       end
     end
-    render :nothing => true, :status => 200, :content_type => 'application/json'
+    render :nothing => true, :status => 200, :content_type => 'text/html'
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -38,4 +38,22 @@ class Person < ActiveRecord::Base
   def self.users
     Person.includes(:user).where.not(users: {id: nil})
   end
+
+  def email=(new_email)
+    #  Do not set email if user has a pending email change.  The
+    #  user model will set the email for us after it clears
+    #  the pending change.
+    if user.nil? or not user.has_pending_email_change?
+        self[:email] = new_email
+    end
+  end
+
+  def has_pending_email_change?
+    if not user.nil?
+      user.has_pending_email_change?
+    else
+      false
+    end
+  end
+
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,6 +19,7 @@ class Person < ActiveRecord::Base
   has_one :user, autosave: true
   validates_presence_of :firstname, :lastname, :household
   validates_associated :household
+  validate :custom_validate
 
   def fullname
     if lastname
@@ -56,4 +57,18 @@ class Person < ActiveRecord::Base
     end
   end
 
+  def add_custom_error(attribute, message)
+    if @custom_errors.nil?
+      @custom_errors = {}
+    end
+    @custom_errors[attribute] = message
+  end
+
+  def custom_validate
+    if not @custom_errors.nil?
+      @custom_errors.each do |k, v|
+        errors.add(k.to_sym, v)
+      end
+    end
+  end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -42,8 +42,8 @@ class Person < ActiveRecord::Base
 
   def email=(new_email)
     #  Do not set email if user has a pending email change.  The
-    #  user model will set the email for us after it clears
-    #  the pending change.
+    #  confirm_email_change on the people controller will set the email
+    #  after the change has been confirmed for the user
     if user.nil? or not user.has_pending_email_change?
         self[:email] = new_email
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,7 @@ class User < ActiveRecord::Base
   end
 
   def should_send_confirmation_email?
-    send_confirmation
+    @send_confirmation
   end
 
   def send_confirmation_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,8 +29,6 @@ class User < ActiveRecord::Base
   has_many :roles, :through => :user_roles
   belongs_to :person, autosave: true
 
-  attr_reader :send_confirmation
-
   @send_confirmation = false
 
   def send_new_account_instructions
@@ -68,7 +66,7 @@ class User < ActiveRecord::Base
 
   def confirm_email_change
     if has_pending_email_change?
-        self[:email] = self[:pending_email]
+      self[:email] = self[:pending_email]
       cancel_pending_email_change
     end
   end
@@ -79,9 +77,14 @@ class User < ActiveRecord::Base
     self[:pending_email]             = nil
   end
 
+  def should_send_confirmation_email?
+    send_confirmation
+  end
+
   def send_confirmation_email
     send_devise_notification(:confirmation_instructions, reset_email_token, {})
   end
+
   def has_pending_email_change?
     return ( not pending_email.nil? and not reset_email_token_sent_at.nil? and ( reset_email_token_sent_at > ( DateTime.now - Devise.confirm_within ) ) )
   end
@@ -92,6 +95,7 @@ class User < ActiveRecord::Base
     end
     return true
   end
+
   def validate_pending_email
       if not pending_email_valid?
         errors.add(:email, "already exists")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,8 +66,10 @@ class User < ActiveRecord::Base
   end
 
   def confirm_email_change
-    self[:email] = self[:pending_email]
-    cancel_pending_email_change
+    if has_pending_email_change?
+        self[:email] = self[:pending_email]
+      cancel_pending_email_change
+    end
   end
 
   def cancel_pending_email_change

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :trackable, :validatable
+  validate :validate_pending_email
 
   has_many :user_roles
   has_many :roles, :through => :user_roles
@@ -83,5 +84,17 @@ class User < ActiveRecord::Base
   end
   def has_pending_email_change?
     return ( not pending_email.nil? and not reset_email_token_sent_at.nil? and ( reset_email_token_sent_at > ( DateTime.now - Devise.confirm_within ) ) )
+  end
+
+  def pending_email_valid?
+    if has_pending_email_change? and User.find_by_email(pending_email) != nil
+      return false
+    end
+    return true
+  end
+  def validate_pending_email
+      if not pending_email_valid?
+        errors.add(:email, "already exists")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,10 @@ class User < ActiveRecord::Base
   has_many :roles, :through => :user_roles
   belongs_to :person, autosave: true
 
+  attr_reader :send_confirmation
+
+  @send_confirmation = false
+
   def send_new_account_instructions
      token = set_reset_password_token
      send_new_account_instructions_notification(token)
@@ -55,6 +59,7 @@ class User < ActiveRecord::Base
       self[:reset_email_token] = Devise.friendly_token
       self[:reset_email_token_sent_at] = DateTime.now
       self[:pending_email] = new_email
+      @send_confirmation = true
     else
       self[:email] = new_email
     end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -37,6 +37,20 @@ class PersonPolicy < ApplicationPolicy
   def search?
     index?
   end
+
+  def cancel_pending_email_change?
+    @user.has_access?(PERM_RW_PERSON)
+  end
+
+  def send_confirmation_email?
+    @user.has_access?(PERM_RW_PERSON)
+  end
+
+  # Email confirmations should not require a login, so we will always authorize.
+  # The token in the URL is the real authorization mechanism.
+  def confirm_email_change?
+    true
+  end
   # def scope
   #   Pundit.policy_scope!(user, Person)
   # end

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_for(@person) do |f| %>
-  <% if @person.errors.any? %>
+  <% if @person.errors.any? or @errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@person.errors.count, "error") %> prohibited this person from being saved:</h2>
 

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -26,25 +26,29 @@
   <div class="field">
     <%= f.label :email %>
     <% if @person.has_pending_email_change? %>
-        <div id="pending_email_change_div" style="border: 1px solid #ccc; padding:10px 10px 0px 10px;">
-          <div class="row">
-            <div class="small-12 columns">
-              <p>
-                This user has a pending email change from <i><%= @person.user.email %></i> to <i><%= @person.user.pending_email %></i>.
-                A confirmation email has been sent to <i><%= @person.user.pending_email %></i>.  You can can either cancel this change or re-send the confirmation link to this email.
-              </p>
+        <% if @person.user.pending_email_valid? %>
+          <div id="pending_email_change_div" style="border: 1px solid #ccc; padding:10px 10px 0px 10px;">
+            <div class="row">
+              <div class="small-12 columns">
+                <p>
+                  This user has a pending email change from <i><%= @person.user.email %></i> to <i><%= @person.user.pending_email %></i>.
+                  A confirmation email has been sent to <i><%= @person.user.pending_email %></i>.  You can can either cancel this change or re-send the confirmation link to this email.
+                </p>
+              </div>
+            </div>
+            <div class="row" style="margin-top:20px;">
+              <div class="small-12 medium-6 columns">
+                <button class="button tiny center-block" type="button" onclick="resendEmailConfirmation();" >Resend Confirmation Email</button>
+              </div>
+              <div class="small-12 medium-6 columns">
+                <button class="button tiny" type="button" onclick="cancelEmailChange();">Cancel Email Change</button>
+              </div>
             </div>
           </div>
-          <div class="row" style="margin-top:20px;">
-            <div class="small-12 medium-6 columns">
-              <button class="button tiny center-block" type="button" onclick="resendEmailConfirmation();" >Resend Confirmation Email</button>
-            </div>
-            <div class="small-12 medium-6 columns">
-              <button class="button tiny" type="button" onclick="cancelEmailChange();">Cancel Email Change</button>
-            </div>
-          </div>
-        </div>
         <%= f.email_field :email, style: "display: none;" %>
+        <% else %>
+          <%= f.email_field :email, :value => @person.user.pending_email %>
+        <% end %>
     <% else %>
       <%= f.email_field :email %>
     <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -44,7 +44,7 @@
             </div>
           </div>
         </div>
-        <%= f.email_field :email, style: "display: none;", disabled: "disabled" %>
+        <%= f.email_field :email, style: "display: none;" %>
     <% else %>
       <%= f.email_field :email %>
     <% end %>
@@ -128,10 +128,19 @@
         });
     });
 
+    <% if not @person.id.nil? %>
+
     function resendEmailConfirmation() {
       $.ajax({
         url: '<%= send_confirmation_email_url %>',
-        method: 'POST'
+        method: 'POST',
+        accept: 'applicaiton/json'
+      }).done(function (data, textStatus, jqXHR) {
+        $("#notice_content").html("Confirmation email sent");
+        $("#notice").show().delay(3000).fadeOut(1000);
+      }).fail(function (jqXHR, textStatus, errorThrown) {
+        $("#error_content").html("Error sending confirmation email");
+        $("#error").show().delay(3000).fadeOut(1000);
       });
     }
 
@@ -139,9 +148,16 @@
       $.ajax({
         url: '<%= cancel_pending_email_change_url %>',
         method: 'DELETE'
-      });
-      $('#person_email').show();
-      $('#person_email').removeAttr("disabled");
-      $('#pending_email_change_div').hide();
+      }).done(function (data, textStatus, jqXHR) {
+        $("#notice_content").html("Pending email change was canceled");
+        $("#notice").show().delay(3000).fadeOut(1000);
+        $('#person_email').show();
+        $('#person_email').removeAttr("disabled");
+        $('#pending_email_change_div').hide();
+      }).fail(function (jqXHR, textStatus, errorThrown) {
+        $("#error_content").html("Error canceling pending email change");
+        $("#error").show().delay(3000).fadeOut(1000);
+      });;
     }
+  <% end %>
 </script>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -45,7 +45,7 @@
               </div>
             </div>
           </div>
-        <%= f.email_field :email, style: "display: none;" %>
+          <%= f.email_field :email, style: "display: none;" %>
         <% else %>
           <%= f.email_field :email, :value => @person.user.pending_email %>
         <% end %>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -24,8 +24,30 @@
     <%= f.text_field :lastname %>
   </div>
   <div class="field">
-      <%= f.label :email %>
+    <%= f.label :email %>
+    <% if @person.has_pending_email_change? %>
+        <div id="pending_email_change_div" style="border: 1px solid #ccc; padding:10px 10px 0px 10px;">
+          <div class="row">
+            <div class="small-12 columns">
+              <p>
+                This user has a pending email change from <i><%= @person.user.email %></i> to <i><%= @person.user.pending_email %></i>.
+                A confirmation email has been sent to <i><%= @person.user.pending_email %></i>.  You can can either cancel this change or re-send the confirmation link to this email.
+              </p>
+            </div>
+          </div>
+          <div class="row" style="margin-top:20px;">
+            <div class="small-12 medium-6 columns">
+              <button class="button tiny center-block" type="button" onclick="resendEmailConfirmation();" >Resend Confirmation Email</button>
+            </div>
+            <div class="small-12 medium-6 columns">
+              <button class="button tiny" type="button" onclick="cancelEmailChange();">Cancel Email Change</button>
+            </div>
+          </div>
+        </div>
+        <%= f.email_field :email, style: "display: none;", disabled: "disabled" %>
+    <% else %>
       <%= f.email_field :email %>
+    <% end %>
   </div>
   <div class="field">
     <%= f.label :phone %>
@@ -105,4 +127,21 @@
             }
         });
     });
+
+    function resendEmailConfirmation() {
+      $.ajax({
+        url: '<%= send_confirmation_email_url %>',
+        method: 'POST'
+      });
+    }
+
+    function cancelEmailChange() {
+      $.ajax({
+        url: '<%= cancel_pending_email_change_url %>',
+        method: 'DELETE'
+      });
+      $('#person_email').show();
+      $('#person_email').removeAttr("disabled");
+      $('#pending_email_change_div').hide();
+    }
 </script>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -29,7 +29,7 @@
       <div class="small-12 columns">
         <p>
           <strong>Email</strong><br/>
-          <%= @person.email %>
+          <%= @person.email %><% if @person.has_pending_email_change? %><i> (Pending change to: <%= @person.user.pending_email %>)</i><% end %>
         </p>
       </div>
       <% if @person.user %>

--- a/app/views/users/email/confirm_email_change.html.erb
+++ b/app/views/users/email/confirm_email_change.html.erb
@@ -1,0 +1,5 @@
+<div class="row">
+  <div class="small-12 columns">
+      Your email change has been confirmed!
+  </div>
+</div>

--- a/app/views/users/email/confirm_email_change.html.erb
+++ b/app/views/users/email/confirm_email_change.html.erb
@@ -1,5 +1,32 @@
 <div class="row">
-  <div class="small-12 columns">
-      Your email change has been confirmed!
-  </div>
+  <% if @errors.any? %>
+      <div class="small-12 columns red-text center-block" style="margin-top:20px;">
+        <div id="error_explanation" class="center-block" style="margin-left:auto;  margin-right:auto;">
+          <h2>The following error(s) occured trying to confirm your email change:</h2>
+          <ul>
+            <% if @errors.any? %>
+                <% if @errors %>
+                    <% @errors.each do |msg| %>
+                        <li><%= msg %></li>
+                    <% end %>
+                <% end %>
+            <% else %>
+                <li>Unknown</li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+      <div class="small-12 columns text-center">
+        <p>You should login with your old email and resolve the problem(s) mentioned above.</p>
+        <% if (user_signed_in?) %>
+            <%= link_to "Start Serving", people_path, class: "button" %>
+        <% else %>
+            <%= link_to "Login", new_user_session_path, class: "button" %>
+        <% end %>
+      </div>
+  <% else %>
+    <div class="small-12 columns text-center green-text">
+        <h1 class="green-text">Your email change has been confirmed!</h1>
+    </div>
+      <% end %>
 </div>

--- a/app/views/users/email/invalid_token.html.erb
+++ b/app/views/users/email/invalid_token.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="small-12 columns">
-    <h1 style="color:#cc0000;" class="text-center">This confirmation token is not valid<br/>Please login using your old username/email and click re-send confirmation email.</h1>
+    <h1 class="text-center red-text">This confirmation token is not valid<br/>Please login using your old username/email and click re-send confirmation email.</h1>
   </div>
 </div>
 <div class="row" style="margin-top:20px;">

--- a/app/views/users/email/invalid_token.html.erb
+++ b/app/views/users/email/invalid_token.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="small-12 columns">
+    <h1 style="color:#cc0000;" class="text-center">This confirmation token is not valid<br/>Please login using your old username/email and click re-send confirmation email.</h1>
+  </div>
+</div>
+<div class="row" style="margin-top:20px;">
+  <div class="small-12 columns text-center">
+    <% if (user_signed_in?) %>
+        <%= link_to "Start Serving", people_path, class: "button" %>
+    <% else %>
+        <%= link_to "Login", new_user_session_path, class: "button" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', confirm_email_change_url(@resource.person, confirmation_token: @resource.reset_email_token) %></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -113,7 +113,7 @@ Devise.setup do |config|
   # their account can't be confirmed with the token any more.
   # Default is nil, meaning there is no restriction on how long a user can take
   # before confirming their account.
-  # config.confirm_within = 3.days
+  config.confirm_within = 3.days
 
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,10 @@ Thirtyone::Application.routes.draw do
     end
   end
 
+  delete '/people/:id/email_change'     => 'people#cancel_pending_email_change', as: 'cancel_pending_email_change'
+  post '/people/:id/email_confirmation' => 'people#send_confirmation_email', as: 'send_confirmation_email'
+  get '/people/:id/email_confirmation'  => 'people#confirm_email_change', as: 'confirm_email_change'
+
   match '/people/new', :controller => 'people', :action => 'new', via: :post
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/db/migrate/20151110010534_add_email_change_to_users.rb
+++ b/db/migrate/20151110010534_add_email_change_to_users.rb
@@ -1,0 +1,7 @@
+class AddEmailChangeToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :reset_email_token, :string
+    add_column :users, :reset_email_token_sent_at, :datetime
+    add_column :users, :pending_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027001604) do
+ActiveRecord::Schema.define(version: 20151110010534) do
 
   create_table "addresses", force: :cascade do |t|
     t.string   "line1",      limit: 255
@@ -165,6 +165,9 @@ ActiveRecord::Schema.define(version: 20151027001604) do
     t.string   "current_sign_in_ip",     limit: 255
     t.string   "last_sign_in_ip",        limit: 255
     t.integer  "person_id"
+    t.string   "reset_email_token"
+    t.datetime "reset_email_token_sent_at"
+    t.string   "pending_email"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,6 +80,7 @@ end
 
 # This may look weird, but it neccessary to jump around all the devise validation code.  Without it the user would not save as the email is invalid and the password is too short
 user = User.find_or_initialize_by({email: 'admin'})
+user.confirm_email_change
 user.password = 'admin'
 admin_role = Role.find_by({name: 'Admin'})
 user.roles << admin_role if not user.roles.include?(admin_role)


### PR DESCRIPTION
When an email change is made for someone who is a user, they should be required to confirm their ability to send and receive email from the new address.

Closes #68 