### PR TITLE
Fixes #171 - Soft delete people records (set deleted_at)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'figaro'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 
+gem 'paranoia', '~> 2.0'
+
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    paranoia (2.1.5)
+      activerecord (~> 4.0)
     parser (2.3.0.6)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -263,6 +265,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails (>= 3.0)
   jquery-ui-rails
+  paranoia (~> 2.0)
   pundit
   quiet_assets
   rails (~> 4)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -13,6 +13,7 @@
 #
 
 class Person < ActiveRecord::Base
+  acts_as_paranoid
 #  has_notes
   has_and_belongs_to_many :notes
   belongs_to :household, autosave: true

--- a/db/migrate/20160229151430_add_deleted_at_to_people.rb
+++ b/db/migrate/20160229151430_add_deleted_at_to_people.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToPeople < ActiveRecord::Migration
+  def change
+    add_column :people, :deleted_at, :datetime
+    add_index :people, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110010534) do
+ActiveRecord::Schema.define(version: 20160229151430) do
 
   create_table "addresses", force: :cascade do |t|
     t.string   "line1"
@@ -128,7 +128,10 @@ ActiveRecord::Schema.define(version: 20151110010534) do
     t.datetime "updated_at"
     t.integer  "household_id"
     t.string   "email"
+    t.datetime "deleted_at"
   end
+
+  add_index "people", ["deleted_at"], name: "index_people_on_deleted_at"
 
   create_table "roles", force: :cascade do |t|
     t.datetime "created_at"


### PR DESCRIPTION
See https://github.com/rubysherpas/paranoia#usage for usage.

If a model is marked as 'acts_as_paranoid', then calling #destroy will set the deleted_at column to the current timestamp.  You'll need to create a migration to add that column to a model before you can use it.  

Be sure to check out the linked documentation for information about how dependent records are handled.