### PR TITLE
Added a select? method to household policy

### DIFF
--- a/app/policies/household_policy.rb
+++ b/app/policies/household_policy.rb
@@ -25,4 +25,8 @@ class HouseholdPolicy < ApplicationPolicy
   def search?
     @user.has_access? PERM_RO_PERSON
   end
+
+  def select?
+    @user.has_access? PERM_RW_PERSON
+  end
 end


### PR DESCRIPTION
The select or create a household button on the edit person page was
throwing a 500 error because the household_policy did not have a rule for select?