### PR TITLE
Allow Inventory Household Limits

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,8 +30,20 @@ function remove_fields(link) {
     $(link).closest(".fields").hide();
 }
 
-function add_fields(link, association, content) {
+function add_fields(link, association, content, parent_selector) {
+    if ( parent_selector != null ) {
+        parent = $(parent_selector);
+    } else {
+        parent = $(link).parent().parent();
+    }
     var new_id = new Date().getTime();
     var regexp = new RegExp("new_" + association, "g")
-    $(link).parent().before(content.replace(regexp, new_id));
+    $(parent).append(content.replace(regexp, new_id));
 }
+
+$(function () {
+    $('.center-vertical').each(function (index) {
+        var row = $(this).closest('.row');
+        $(this).height($(row).height());
+    });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,14 @@
 //= require app.work_schedule.js
 //= require app.calendar.js
 //= require validatejs
+
+function remove_fields(link) {
+    $(link).prev("input[type=hidden]").val("1");
+    $(link).closest(".fields").hide();
+}
+
+function add_fields(link, association, content) {
+    var new_id = new Date().getTime();
+    var regexp = new RegExp("new_" + association, "g")
+    $(link).parent().before(content.replace(regexp, new_id));
+}

--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -56,3 +56,16 @@
     background-color: #ececec;
   }
 }
+
+.layout-wrapper {
+  border: none;
+  margin: 0em;
+  padding: 0em;
+  background: rgba(0, 0, 0, 0.0); /* Transparent */
+  tr {
+    background: rgba(0, 0, 0, 0.0) !important; /* Transparent */
+  }
+  td {
+    padding: 0em;
+  }
+}

--- a/app/controllers/household_controller.rb
+++ b/app/controllers/household_controller.rb
@@ -64,6 +64,8 @@ class HouseholdController < ApplicationController
 
   def update
     @household.address.update(address_params)
+    @household.update(household_limit_params)
+
     respond_to do |format|
       format.html { redirect_to @household, notice: 'Household was successfully updated.' }
     end
@@ -205,12 +207,16 @@ class HouseholdController < ApplicationController
   end
 
   def household_params
-    params.require(:household).permit(:address)
+    params.require(:household).permit(:address, :household_limit => [])
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def address_params
     params.require(:address).permit(:line1, :line2, :city, :state, :zip, :state_id)
+  end
+
+  def household_limit_params
+    params.require(:household).permit(household_limits_attributes:[:inventory_item_id, :quantity, :id, :_destroy])
   end
 
   def authorize_household

--- a/app/controllers/inventory_items_controller.rb
+++ b/app/controllers/inventory_items_controller.rb
@@ -79,6 +79,6 @@ class InventoryItemsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def inventory_item_params
-      params.require(:inventory_item).permit(:name, :quantity, :barcode, :unit)
+      params.require(:inventory_item).permit(:name, :quantity, :barcode, :unit, :default_limit, :limit_reset_after_days)
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,12 +22,21 @@ module ApplicationHelper
     f.hidden_field(:_destroy) + link_to(name, "javascript:;", :onclick => "remove_fields(this)")
   end
 
-  def link_to_add_fields(name, f, association)
+  def link_to_add_fields(name, f, association, parent_selector=nil)
     new_object = f.object.class.reflect_on_association(association).klass.new
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
       render(association.to_s.singularize + "_fields", :f => builder)
     end
-    link_to name, "javascript:;", :class => 'button medium', :onclick => "add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\")"
+    onclick = "add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\""
+    if parent_selector
+      onclick += ", \"#{parent_selector}\""
+    end
+    onclick += ")"
+
+    link_to name,
+            "javascript:;",
+            :class => 'button medium',
+            :onclick => onclick
   end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,6 +22,18 @@ module ApplicationHelper
     f.hidden_field(:_destroy) + link_to(name, "javascript:;", :onclick => "remove_fields(this)")
   end
 
+  # Creates a link/button that has an onclick attribute to call the add_fields javascript found in application.js
+  # The javascript gets passed the link/button which it will use to find it's relative location on the page.  It will also
+  # pass the name of the assocation, which will be used to find and rename the html input fields, and it will be passed HTML which
+  # will be the HTML that gets inserted when the link/button is clicked.  The javascript inserts at $(this).parent().parent(), but
+  # this behavior can be overriden by passing a jQuery selector in as parent_selector.
+  #
+  #
+  # @param name [String] the name of the button/link that will appear on the screen
+  # @param f [FormBuilder] the rails FormBuilder for the form this association will go into
+  # @param association [Symbol] the name of the association you want to generate HTML for
+  # @param parent_selector [String] an option string that will be used by the javascript to find an element to insert the generated HTML
+  #
   def link_to_add_fields(name, f, association, parent_selector=nil)
     new_object = f.object.class.reflect_on_association(association).klass.new
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,17 @@ module ApplicationHelper
   def is_duplicate?(person)
     Person.select { |p| p.id != person.id && p.fullname == person.fullname }.any?
   end
+
+  def link_to_remove_fields(name, f)
+    f.hidden_field(:_destroy) + link_to(name, "javascript:;", :onclick => "remove_fields(this)")
+  end
+
+  def link_to_add_fields(name, f, association)
+    new_object = f.object.class.reflect_on_association(association).klass.new
+    fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
+      render(association.to_s.singularize + "_fields", :f => builder)
+    end
+    link_to name, "javascript:;", :class => 'button medium', :onclick => "add_fields(this, \"#{association}\", \"#{escape_javascript(fields)}\")"
+  end
+
 end

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -17,7 +17,9 @@ class Household < ActiveRecord::Base
   alias_method :head, :person
   alias_method :head=, :person=
   has_many :members, class_name: 'Person', foreign_key: 'household_id'
+  has_many :household_limits
   accepts_nested_attributes_for :address
+  accepts_nested_attributes_for :household_limits, allow_destroy: true
   validates_associated :address
 
   acts_as_paranoid

--- a/app/models/household_limit.rb
+++ b/app/models/household_limit.rb
@@ -1,0 +1,4 @@
+class HouseholdLimit < ActiveRecord::Base
+  belongs_to :inventory_item
+  belongs_to :household
+end

--- a/app/policies/household_policy.rb
+++ b/app/policies/household_policy.rb
@@ -50,4 +50,7 @@ class HouseholdPolicy < ApplicationPolicy
     merge_select?
   end
 
+  def update?
+    true
+  end
 end

--- a/app/policies/household_policy.rb
+++ b/app/policies/household_policy.rb
@@ -51,6 +51,6 @@ class HouseholdPolicy < ApplicationPolicy
   end
 
   def update?
-    true
+    edit?
   end
 end

--- a/app/views/household/_edit.html.erb
+++ b/app/views/household/_edit.html.erb
@@ -5,6 +5,7 @@
         <label class="required" for="household_name">Household Name</label>
         <input disabled="disabled" type="text" value="<% if not @household.new_record? %><%= @household.name %><% end %>" />
       </div>
+    </div>
       <div class="small-12 columns">
         <%= fields_for :address, @household.address do |a| %>
             <div class="field">
@@ -29,7 +30,6 @@
             </div>
         <% end %>
       </div>
-    </div>
     <input type="hidden" id="person_household_id" name="person[household_id]" value="" />
 <% end %>
 </div>

--- a/app/views/household/_household_limit_fields.html.erb
+++ b/app/views/household/_household_limit_fields.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr class="fields">
     <td>
       <div class="small-6 columns">
         <label>Iventory Item</label>

--- a/app/views/household/_household_limit_fields.html.erb
+++ b/app/views/household/_household_limit_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="fields text-center">
+  <div class="small-5 columns">
+    <div class="field">
+      <%= f.label :household_limit_inventroy_item, "Iventory Item" %>
+      <%= f.collection_select :inventory_item_id, InventoryItem.all, :id, :name %>
+    </div>
+  </div>
+  <div class="small-5 columns">
+    <div class="field">
+      <%= f.label :household_limit_item, "Quantity Override" %>
+      <%= f.text_field :quantity %>
+    </div>
+  </div>
+  <div class="small-2 columns" >
+    <p><%= link_to_remove_fields "Remove", f %></p>
+  </div>
+</div>

--- a/app/views/household/_household_limit_fields.html.erb
+++ b/app/views/household/_household_limit_fields.html.erb
@@ -1,17 +1,17 @@
-<div class="fields text-center">
-  <div class="small-5 columns">
-    <div class="field">
-      <%= f.label :household_limit_inventroy_item, "Iventory Item" %>
-      <%= f.collection_select :inventory_item_id, InventoryItem.all, :id, :name %>
-    </div>
-  </div>
-  <div class="small-5 columns">
-    <div class="field">
-      <%= f.label :household_limit_item, "Quantity Override" %>
-      <%= f.text_field :quantity %>
-    </div>
-  </div>
-  <div class="small-2 columns" >
-    <p><%= link_to_remove_fields "Remove", f %></p>
-  </div>
-</div>
+<tr>
+    <td>
+      <div class="small-6 columns">
+        <label>Iventory Item</label>
+      </div>
+      <div class="small-6 columns">
+        <label>Quantity Override</label>
+      </div>
+      <div class="small-6 columns">
+        <%= f.collection_select :inventory_item_id, InventoryItem.all, :id, :name %>
+      </div>
+      <div class="small-6 columns">
+        <%= f.text_field :quantity %>
+      </div>
+    </td>
+    <td><%= link_to_remove_fields "Remove", f %></td>
+</tr>

--- a/app/views/household/edit.html.erb
+++ b/app/views/household/edit.html.erb
@@ -3,14 +3,26 @@
   <div style="margin-top:20px;" class="row">
     <div class="small-12 medium-8 large-8 columns small-centered">
       <%= render :partial => 'household/new', :locals => {:f => form} %>
-      <%= form.fields_for :household_limits do |builder| %>
-          <%= render 'household_limit_fields', :f => builder %>
-      <% end %>
-      <div class="small-12 columns">
-        <%= link_to_add_fields "Add Inventory Override", form, :household_limits %>
-      </div>
     </div>
   </div>
+
+    <div class="row">
+      <div class="small-12 medium-8 large-8 columns small-centered">
+        <table id="household_limits_table" class="layout-wrapper">
+            <%= form.fields_for :household_limits do |builder| %>
+                <%= render 'household_limit_fields', :f => builder %>
+            <% end %>
+        </table>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="small-12 medium-8 large-8 columns small-centered">
+        <div class="small-12 columns">
+          <p><%= link_to_add_fields "Add Inventory Override", form, :household_limits, "#household_limits_table" %></p>
+        </div>
+      </div>
+    </div>
 
   <div class="row">
     <div class="large-8 small-12 columns small-centered">

--- a/app/views/household/edit.html.erb
+++ b/app/views/household/edit.html.erb
@@ -1,30 +1,35 @@
 <%= form_for(@household) do |form| %>
 
-
-<div style="margin-top:20px;" class="row">
-  <div class="small-12 medium-8 large-8 columns small-centered">
-    <%= render :partial => 'household/new', :locals => {:f => form} %>
-        <%# render 'edit' %>
-  </div>
-</div>
-<div class="row">
-  <div class="large-8 small-12 columns small-centered">
-    <div class="small-12 columns">
-      <h3>Members</h3>
-      <% @household.members.each do |member| %>
-          <li><%= link_to member.formal_name, edit_person_path(member, :redirect_to_url => edit_household_path(@household)) %></li>
+  <div style="margin-top:20px;" class="row">
+    <div class="small-12 medium-8 large-8 columns small-centered">
+      <%= render :partial => 'household/new', :locals => {:f => form} %>
+      <%= form.fields_for :household_limits do |builder| %>
+          <%= render 'household_limit_fields', :f => builder %>
       <% end %>
+      <div class="small-12 columns">
+        <%= link_to_add_fields "Add Inventory Override", form, :household_limits %>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="row space-above">
-  <div class="large-8 columns small-12 small-centered clearfix">
-    <div class="small-12 columns">
-      <%= form.submit 'Save', :class => 'medium button left' %>
-      <%= link_to("New Person", new_person_path(:household_id => @household.id, :redirect_to_url => edit_household_path(@household)), :class => 'button medium right') %>
+  <div class="row">
+    <div class="large-8 small-12 columns small-centered">
+      <div class="small-12 columns">
+        <h3>Members</h3>
+        <% @household.members.each do |member| %>
+            <li><%= link_to member.formal_name, edit_person_path(member, :redirect_to_url => edit_household_path(@household)) %></li>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
+
+  <div class="row space-above">
+    <div class="large-8 columns small-12 small-centered clearfix">
+      <div class="small-12 columns">
+        <%= form.submit 'Save', :class => 'medium button left' %>
+        <%= link_to("New Person", new_person_path(:household_id => @household.id, :redirect_to_url => edit_household_path(@household)), :class => 'button medium right') %>
+      </div>
+    </div>
+  </div>
 
 <% end %>

--- a/app/views/household/show.html.erb
+++ b/app/views/household/show.html.erb
@@ -20,3 +20,8 @@
     <a class="close-reveal-modal">&#215;</a>
   </div>
 </div>
+<div class="row space-above">
+  <div class="large-10 small-12 large-offset-2 columns">
+    <%= link_to('Add Inventory Limit Override', edit_household_path(@household), :class => 'button medium') if current_user and current_user.has_access?(PERM_RW_PERSON) %>
+  </div>
+</div>

--- a/app/views/household/show.html.erb
+++ b/app/views/household/show.html.erb
@@ -20,8 +20,3 @@
     <a class="close-reveal-modal">&#215;</a>
   </div>
 </div>
-<div class="row space-above">
-  <div class="large-10 small-12 large-offset-2 columns">
-    <%= link_to('Add Inventory Limit Override', edit_household_path(@household), :class => 'button medium') if current_user and current_user.has_access?(PERM_RW_PERSON) %>
-  </div>
-</div>

--- a/app/views/inventory_items/_edit.html.erb
+++ b/app/views/inventory_items/_edit.html.erb
@@ -4,11 +4,11 @@
 
 <div class="row">
   <div class="left">
-    <button class="medium" onclick="$('#edit_inventory_item_<%= @inventory_item.id %>').submit();">Save</button>
-    <button class="medium" onclick="$('#editInventoryModal').foundation('reveal', 'close');">Cancel</button>
+    <a class="button medium" onclick="$('#edit_inventory_item_<%= @inventory_item.id %>').submit();">Save</a>
+    <a class="button medium" onclick="$('#editInventoryModal').foundation('reveal', 'close');">Cancel</a>
   </div>
 <div class="right">
-  <button class="medium" onclick="if ( confirm('Are you sure you want to completely remove <%= @inventory_item.name %> from your inventory?') ) {
+  <a class="button medium" onclick="if ( confirm('Are you sure you want to completely remove <%= @inventory_item.name %> from your inventory?') ) {
           var request = $.ajax({
                   url: '<%= inventory_item_path(@inventory_item.id) %>',
                   type: 'DELETE',
@@ -20,6 +20,6 @@
           request.fail(function( jqXHR, textStatus) {
                   alert('Delete failed with message: ' + textStatus);
            });
-          }">Remove from Inventory</button>
+          }">Remove from Inventory</a>
 </div>
 </div>

--- a/app/views/inventory_items/_form.html.erb
+++ b/app/views/inventory_items/_form.html.erb
@@ -16,8 +16,16 @@
     <%= f.text_field :name %>
   </div>
   <div class="field">
-    <%= f.label :quantity %><br>
+    <%= f.label :quantity, "Quantity in stock" %><br>
     <%= f.number_field :quantity %>
+  </div>
+  <div class="field">
+    <%= f.label :default_limit, "Default limit per household" %><br>
+    <%= f.number_field :default_limit %>
+  </div>
+  <div class="field">
+    <%= f.label :limit_reset_after_days, "Days before limit is reset for household" %><br>
+    <%= f.number_field :limit_reset_after_days %>
   </div>
   <div class="field">
     <%= f.label :barcode %><br>

--- a/app/views/inventory_items/_new.html.erb
+++ b/app/views/inventory_items/_new.html.erb
@@ -2,7 +2,7 @@
 
 <%= render 'form' %>
 
-<button id="save_button" class="medium" onclick="
+<a id="save_button" class="button medium" onclick="
         var form = $('#new_inventory_item');
         var request = $.ajax({
             url: form.attr('action'),
@@ -16,9 +16,9 @@
         request.fail(function( jqXHR, textStatus) {
                 alert('Delete failed with message: ' + textStatus);
                 });
-">Save</button>
+">Save</a>
 
-<button class="medium" onclick="$('#editInventoryModal').foundation('reveal', 'close');">Cancel</button>
+<a class="button medium" onclick="$('#editInventoryModal').foundation('reveal', 'close');">Cancel</a>
 
 <script>
     $("#new_inventory_item").on('keypress', 'input', function(e) {

--- a/app/views/inventory_items/index.html.erb
+++ b/app/views/inventory_items/index.html.erb
@@ -16,6 +16,8 @@
             <tr>
                 <th>Name</th>
                 <th>Quantity</th>
+                <th>Default Household Limit</th>
+                <th>Limit Reset (days)</th>
                 <th>Unit</th>
                 <th>Barcode</th>
             </tr>
@@ -27,6 +29,8 @@
             <tr class="row-link" onclick="$('#editInventoryModal').foundation('reveal', 'open', {url: '<%= edit_inventory_item_path(inventory_item.id) %>', data: {ajax: true}});">
                 <td><%= inventory_item.name %></td>
                 <td><%= inventory_item.quantity %></td>
+                <td><%= inventory_item.default_limit %></td>
+                <td><%= inventory_item.limit_reset_after_days %></td>
                 <td><%= inventory_item.unit %></td>
                 <td><%= inventory_item.barcode %></td>
             </tr>

--- a/app/views/inventory_items/index.html.erb
+++ b/app/views/inventory_items/index.html.erb
@@ -37,7 +37,7 @@
 
     <br>
 
-    <button onclick="$('#editInventoryModal').foundation('reveal', 'open', {url: '<%= new_inventory_item_path %>', data: {ajax: true}});">New Item</button>
+    <a class="button medium" onclick="$('#editInventoryModal').foundation('reveal', 'open', {url: '<%= new_inventory_item_path %>', data: {ajax: true}});">New Item</a>
 
   </div>
 </div>

--- a/app/views/static_pages/_topnav.html.erb
+++ b/app/views/static_pages/_topnav.html.erb
@@ -12,13 +12,11 @@
         <li class="divider"></li>
         <li class="<%= "active" if current_page?(people_path) %>"><a href="<%= people_path %>">Start Serving</a></li>
         <li class="divider"></li>
-      <li class="<%= "active" if current_page?(households_path) %>"><a href="<%= households_path %>">Households</a></li>
-      <li class="divider"></li>
-      <li class="<%= "active" if current_page?(calendar_index_path) %>"><a href="<%= calendar_index_path %>">Scheduling</a></li>
-      <!--
+        <li class="<%= "active" if current_page?(households_path) %>"><a href="<%= households_path %>">Households</a></li>
+        <li class="divider"></li>
+        <li class="<%= "active" if current_page?(calendar_index_path) %>"><a href="<%= calendar_index_path %>">Scheduling</a></li>
         <li class="divider"></li>
         <li class="<%= "active" if current_page?(inventory_items_path) %>"><a href="<%= inventory_items_path %>">Inventory</a></li>
-        -->
         <li class="divider"></li>
         <li><a href="#">Reports</a></li>
         <li class="divider"></li>

--- a/db/migrate/20160604024611_create_household_limits.rb
+++ b/db/migrate/20160604024611_create_household_limits.rb
@@ -1,0 +1,12 @@
+class CreateHouseholdLimits < ActiveRecord::Migration
+  def change
+    create_table :household_limits do |t|
+      t.references :inventory_item, index: true, foreign_key: true
+      t.references :household, index: true, foreign_key: true
+      t.integer :quantity
+      t.integer :reset_after_days
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160604024620_add_default_limits_to_inventory_item.rb
+++ b/db/migrate/20160604024620_add_default_limits_to_inventory_item.rb
@@ -1,0 +1,6 @@
+class AddDefaultLimitsToInventoryItem < ActiveRecord::Migration
+  def change
+    add_column :inventory_items, :default_limit, :integer
+    add_column :inventory_items, :limit_reset_after_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160604003857) do
-
+ActiveRecord::Schema.define(version: 20160604024620) do
   create_table "addresses", force: :cascade do |t|
     t.string   "line1"
     t.string   "line2"
@@ -30,6 +29,18 @@ ActiveRecord::Schema.define(version: 20160604003857) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "household_limits", force: :cascade do |t|
+    t.integer  "inventory_item_id"
+    t.integer  "household_id"
+    t.integer  "quantity"
+    t.integer  "reset_after_days"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
+  add_index "household_limits", ["household_id"], name: "index_household_limits_on_household_id"
+  add_index "household_limits", ["inventory_item_id"], name: "index_household_limits_on_inventory_item_id"
 
   create_table "households", force: :cascade do |t|
     t.string   "name"
@@ -49,6 +60,8 @@ ActiveRecord::Schema.define(version: 20160604003857) do
     t.string   "unit"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "default_limit"
+    t.integer  "limit_reset_after_days"
   end
 
   create_table "inventory_stock_records", force: :cascade do |t|

--- a/spec/factories/household_limits.rb
+++ b/spec/factories/household_limits.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :household_limit do
+    inventory_item nil
+household nil
+quantity 1
+reset_after_days 1
+  end
+
+end

--- a/spec/models/household_limit_spec.rb
+++ b/spec/models/household_limit_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe HouseholdLimit, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR adds Inventory back to the top nav and adds the ability to set household limits on inventory items and a number of days in which to reset that limit.  Ex. A household can have 2 bags every 2 weeks.  

This also adds the ability to set override limits for an inventory item on a per household bases.  So household X could be allowed "3 bags" where the default is "2 bags".

Fixes #237 
