### PR TITLE
Fixes #254

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :update, :cancel_pending_email_change, :send_confirmation_email, :confirm_email_change]
+  before_action :set_user, only: [:edit, :update, :cancel_pending_email_change, :send_confirmation_email, :confirm_email_change, :show_person]
   before_action :authenticate_user!, except: [:confirm_email_change]
   before_action :authorize_user
   before_action :set_common_vars, only: [:edit, :update]
@@ -35,6 +35,12 @@ class UsersController < ApplicationController
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
+  end
+
+  # GET /user/1
+  # Redirect to the person show page
+  def show_person
+    redirect_to @user.person
   end
 
   # This is an AJAX only method, there is no page to be displayed.  It just invokes an action.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
     else
       respond_to do |format|
         # TODO: This line is broken. It needs to redirect to the edit page and have errors
-        format.html { render action: 'edit' }
+        format.html { redirect_to edit_user_path(@user.id) }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update, :cancel_pending_email_change, :send_confirmation_email, :confirm_email_change]
   before_action :authenticate_user!, except: [:confirm_email_change]
   before_action :authorize_user
+  before_action :set_common_vars, only: [:edit, :update]
 
   # GET /user
   # GET /user.json
@@ -14,8 +15,6 @@ class UsersController < ApplicationController
 
   # GET /user/1/edit
   def edit
-    @can_edit_password = can_edit_password
-    @disable_roles = !current_user.has_access?(PERM_ADMIN)
   end
 
   # PATCH/PUT /user/1
@@ -32,8 +31,7 @@ class UsersController < ApplicationController
       end
     else
       respond_to do |format|
-        # TODO: This line is broken. It needs to redirect to the edit page and have errors
-        format.html { redirect_to edit_user_path(@user.id) }
+        format.html { render action: 'edit' }
         format.json { render json: @user.errors, status: :unprocessable_entity }
       end
     end
@@ -128,5 +126,10 @@ class UsersController < ApplicationController
 
   def authorize_user
     @user ? (authorize @user) : (authorize :user)
+  end
+
+  def set_common_vars
+    @can_edit_password = can_edit_password
+    @disable_roles = !current_user.has_access?(PERM_ADMIN)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -25,6 +25,11 @@ class UserPolicy < ApplicationPolicy
     update?
   end
 
+  # Emulate what is in PersonPolicy#show?
+  def show_person?
+    @logged_in_user.has_access?(PERM_RO_PERSON)
+  end
+
   # Email confirmations should not require a login, so we will always authorize.
   # The token in the URL is the real authorization mechanism.
   def confirm_email_change?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,8 @@ Thirtyone::Application.routes.draw do
 
   root  'static_pages#index'
 
-  # If user refreshes the user 'update' page after getting an error, we want to send them to the edit page
-  match '/user/:id', :controller => 'users', :action => 'edit', via: :get
+  # If user refreshes the user 'update' page after getting an error, we want to send them to the show person page
+  get '/user/:id'  => 'users#show_person'
   resources :user, controller: 'users', only: [:index, :edit, :update]
   resources :role, as: "roles", controller: "roles", via: :all
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Thirtyone::Application.routes.draw do
 
   root  'static_pages#index'
 
+  # If user refreshes the user 'update' page after getting an error, we want to send them to the edit page
+  match '/user/:id', :controller => 'users', :action => 'edit', via: :get
   resources :user, controller: 'users', only: [:index, :edit, :update]
   resources :role, as: "roles", controller: "roles", via: :all
 


### PR DESCRIPTION
Fixes #254.

Now the user can submit edits once they fail their initial user edit. They can also refresh the page after having an edit fail and it will still work as expected.

To see what I mean, do this:

- Find a user, edit their password, but mess up the password edit. (on /user/123/edit)
- The next page you see will now have an error on the password confirmation as expected and the password fields will be editable (thanks to set_common_vars method).
- Also, if you refresh the page you are now on (/user/123), then the page will reload properly because I added a route for /user/123 GET to point to the edit method.